### PR TITLE
feat(metrics): port bespoke in-memory registry to OTel BusinessMetrics

### DIFF
--- a/apps/default/service/metrics/metrics.go
+++ b/apps/default/service/metrics/metrics.go
@@ -1,29 +1,68 @@
+// Package metrics exposes the file service's product metrics through
+// OpenTelemetry. Instruments are created with frame's BusinessMetrics
+// factory, so every measurement transparently carries tenant_id and
+// partition_id derived from the context's security claims. The historic
+// file_service_* metric names are preserved so existing dashboards and
+// alerts keep working; metrics are exported through the service's OTel
+// pipeline instead of the previous bespoke Prometheus text handler.
 package metrics
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
 	"sync"
 	"time"
 
+	"github.com/pitabwire/frame/v2/telemetry"
 	"github.com/pitabwire/util"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 )
 
-// writeIgnoreErr writes to the response writer, ignoring errors
-// For metrics output, we continue even if some writes fail
+const meterName = "file_service"
+
+// writeIgnoreErr writes to the response writer, ignoring errors.
+// For probe output, we continue even if some writes fail.
 func writeIgnoreErr(w io.Writer, format string, args ...any) {
 	_, _ = fmt.Fprintf(w, format, args...)
 }
 
-// Metrics represents the application metrics
+// Metrics wraps the service's OTel instruments behind the same simple
+// recording API the previous in-memory registry offered. A small amount of
+// internal state is retained: gauges (active requests, storage totals) need
+// current values to record, and the Get* accessors used by tests and
+// diagnostics read from it.
 type Metrics struct {
-	// Request metrics
+	// Request instruments.
+	requestsTotalCounter telemetry.Counter
+	activeRequestsGauge  telemetry.Gauge
+
+	// File transfer instruments.
+	uploadsCounter        telemetry.Counter
+	uploadBytesCounter    telemetry.Counter
+	uploadErrorsCounter   telemetry.Counter
+	downloadsCounter      telemetry.Counter
+	downloadBytesCounter  telemetry.Counter
+	downloadErrorsCounter telemetry.Counter
+
+	// Storage instruments.
+	storageBytesGauge        telemetry.Gauge
+	storageFilesGauge        telemetry.Gauge
+	storageUsersGauge        telemetry.Gauge
+	storagePublicBytesGauge  telemetry.Gauge
+	storagePrivateBytesGauge telemetry.Gauge
+
+	// Cache instruments.
+	cacheHitsCounter   telemetry.Counter
+	cacheMissesCounter telemetry.Counter
+
+	// Internal state backing gauges and the Get* accessors.
 	requestsTotal    map[string]int64
 	requestsDuration map[string][]time.Duration
 	activeRequests   int64
 
-	// File metrics
 	uploadsTotal   int64
 	downloadsTotal int64
 	uploadBytes    int64
@@ -31,23 +70,53 @@ type Metrics struct {
 	uploadErrors   int64
 	downloadErrors int64
 
-	// Storage metrics
 	totalBytesStored   int64
 	totalFilesStored   int64
 	totalUsers         int64
 	publicBytesStored  int64
 	privateBytesStored int64
 
-	// Cache metrics
 	cacheHits   map[string]int64
 	cacheMisses map[string]int64
 
 	mu sync.RWMutex
 }
 
-// NewMetrics creates a new metrics instance
+// NewMetrics creates a new metrics instance with all OTel instruments
+// registered under their historic file_service_* names.
 func NewMetrics() *Metrics {
+	bm := telemetry.NewBusinessMetrics(meterName)
+
 	return &Metrics{
+		requestsTotalCounter: bm.Counter("file_service_requests_total", "Total requests"),
+		activeRequestsGauge:  bm.Gauge("file_service_active_requests", "Current number of active requests"),
+
+		uploadsCounter: bm.Counter("file_service_uploads_total", "Total number of file uploads"),
+		uploadBytesCounter: bm.Counter(
+			"file_service_upload_bytes_total", "Total bytes uploaded", metric.WithUnit("B"),
+		),
+		uploadErrorsCounter: bm.Counter("file_service_upload_errors_total", "Total number of upload errors"),
+		downloadsCounter:    bm.Counter("file_service_downloads_total", "Total number of file downloads"),
+		downloadBytesCounter: bm.Counter(
+			"file_service_download_bytes_total", "Total bytes downloaded", metric.WithUnit("B"),
+		),
+		downloadErrorsCounter: bm.Counter("file_service_download_errors_total", "Total number of download errors"),
+
+		storageBytesGauge: bm.Gauge(
+			"file_service_storage_bytes_total", "Total bytes stored", metric.WithUnit("B"),
+		),
+		storageFilesGauge: bm.Gauge("file_service_storage_files_total", "Total files stored"),
+		storageUsersGauge: bm.Gauge("file_service_storage_users_total", "Total users"),
+		storagePublicBytesGauge: bm.Gauge(
+			"file_service_storage_public_bytes_total", "Public bytes stored", metric.WithUnit("B"),
+		),
+		storagePrivateBytesGauge: bm.Gauge(
+			"file_service_storage_private_bytes_total", "Private bytes stored", metric.WithUnit("B"),
+		),
+
+		cacheHitsCounter:   bm.Counter("file_service_cache_hits_total", "Cache hits total"),
+		cacheMissesCounter: bm.Counter("file_service_cache_misses_total", "Cache misses total"),
+
 		requestsTotal:    make(map[string]int64),
 		requestsDuration: make(map[string][]time.Duration),
 		cacheHits:        make(map[string]int64),
@@ -55,33 +124,36 @@ func NewMetrics() *Metrics {
 	}
 }
 
-// RecordRequest records a request
-func (m *Metrics) RecordRequest(method, path string, duration time.Duration, statusCode int) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
+// RecordRequest records a completed request for the given endpoint.
+func (m *Metrics) RecordRequest(ctx context.Context, method, path string, duration time.Duration, _ int) {
 	key := method + ":" + path
+
+	m.mu.Lock()
 	m.requestsTotal[key]++
 	m.requestsDuration[key] = append(m.requestsDuration[key], duration)
 
-	// Keep only last 1000 durations to avoid memory issues
+	// Keep only last 1000 durations to avoid memory issues.
 	if len(m.requestsDuration[key]) > 1000 {
 		m.requestsDuration[key] = m.requestsDuration[key][len(m.requestsDuration[key])-1000:]
 	}
+	m.mu.Unlock()
+
+	m.requestsTotalCounter.Add(ctx, 1, attribute.String("endpoint", key))
 }
 
-// RecordActiveRequest records an active request
-func (m *Metrics) RecordActiveRequest(delta int64) {
+// RecordActiveRequest adjusts the active request gauge by delta.
+func (m *Metrics) RecordActiveRequest(ctx context.Context, delta int64) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	m.activeRequests += delta
+	active := m.activeRequests
+	m.mu.Unlock()
+
+	m.activeRequestsGauge.Record(ctx, active)
 }
 
-// RecordUpload records a file upload
-func (m *Metrics) RecordUpload(size int64, success bool) {
+// RecordUpload records a file upload.
+func (m *Metrics) RecordUpload(ctx context.Context, size int64, success bool) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	m.uploadsTotal++
 	if success {
 		m.uploadBytes += size
@@ -90,50 +162,74 @@ func (m *Metrics) RecordUpload(size int64, success bool) {
 	} else {
 		m.uploadErrors++
 	}
+	totalBytes, totalFiles := m.totalBytesStored, m.totalFilesStored
+	m.mu.Unlock()
+
+	m.uploadsCounter.Add(ctx, 1)
+	if success {
+		m.uploadBytesCounter.Add(ctx, size)
+		m.storageBytesGauge.Record(ctx, totalBytes)
+		m.storageFilesGauge.Record(ctx, totalFiles)
+	} else {
+		m.uploadErrorsCounter.Add(ctx, 1)
+	}
 }
 
-// RecordDownload records a file download
-func (m *Metrics) RecordDownload(size int64, success bool) {
+// RecordDownload records a file download.
+func (m *Metrics) RecordDownload(ctx context.Context, size int64, success bool) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	m.downloadsTotal++
 	if success {
 		m.downloadBytes += size
 	} else {
 		m.downloadErrors++
 	}
+	m.mu.Unlock()
+
+	m.downloadsCounter.Add(ctx, 1)
+	if success {
+		m.downloadBytesCounter.Add(ctx, size)
+	} else {
+		m.downloadErrorsCounter.Add(ctx, 1)
+	}
 }
 
-// RecordStorageStats records storage statistics
-func (m *Metrics) RecordStorageStats(totalBytes, totalFiles, totalUsers, publicBytes, privateBytes int64) {
+// RecordStorageStats records storage statistics.
+func (m *Metrics) RecordStorageStats(ctx context.Context, totalBytes, totalFiles, totalUsers, publicBytes, privateBytes int64) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	m.totalBytesStored = totalBytes
 	m.totalFilesStored = totalFiles
 	m.totalUsers = totalUsers
 	m.publicBytesStored = publicBytes
 	m.privateBytesStored = privateBytes
+	m.mu.Unlock()
+
+	m.storageBytesGauge.Record(ctx, totalBytes)
+	m.storageFilesGauge.Record(ctx, totalFiles)
+	m.storageUsersGauge.Record(ctx, totalUsers)
+	m.storagePublicBytesGauge.Record(ctx, publicBytes)
+	m.storagePrivateBytesGauge.Record(ctx, privateBytes)
 }
 
-// RecordCacheHit records a cache hit
-func (m *Metrics) RecordCacheHit(cacheType string) {
+// RecordCacheHit records a cache hit.
+func (m *Metrics) RecordCacheHit(ctx context.Context, cacheType string) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	m.cacheHits[cacheType]++
+	m.mu.Unlock()
+
+	m.cacheHitsCounter.Add(ctx, 1, attribute.String("cache_type", cacheType))
 }
 
-// RecordCacheMiss records a cache miss
-func (m *Metrics) RecordCacheMiss(cacheType string) {
+// RecordCacheMiss records a cache miss.
+func (m *Metrics) RecordCacheMiss(ctx context.Context, cacheType string) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	m.cacheMisses[cacheType]++
+	m.mu.Unlock()
+
+	m.cacheMissesCounter.Add(ctx, 1, attribute.String("cache_type", cacheType))
 }
 
-// GetRequestMetrics returns request metrics
+// GetRequestMetrics returns request metrics.
 func (m *Metrics) GetRequestMetrics() map[string]int64 {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -141,7 +237,7 @@ func (m *Metrics) GetRequestMetrics() map[string]int64 {
 	return m.requestsTotal
 }
 
-// GetActiveRequests returns the number of active requests
+// GetActiveRequests returns the number of active requests.
 func (m *Metrics) GetActiveRequests() int64 {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -149,7 +245,7 @@ func (m *Metrics) GetActiveRequests() int64 {
 	return m.activeRequests
 }
 
-// GetUploadMetrics returns upload metrics
+// GetUploadMetrics returns upload metrics.
 func (m *Metrics) GetUploadMetrics() (total, bytes, errors int64) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -157,7 +253,7 @@ func (m *Metrics) GetUploadMetrics() (total, bytes, errors int64) {
 	return m.uploadsTotal, m.uploadBytes, m.uploadErrors
 }
 
-// GetDownloadMetrics returns download metrics
+// GetDownloadMetrics returns download metrics.
 func (m *Metrics) GetDownloadMetrics() (total, bytes, errors int64) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -165,7 +261,7 @@ func (m *Metrics) GetDownloadMetrics() (total, bytes, errors int64) {
 	return m.downloadsTotal, m.downloadBytes, m.downloadErrors
 }
 
-// GetStorageMetrics returns storage metrics
+// GetStorageMetrics returns storage metrics.
 func (m *Metrics) GetStorageMetrics() (totalBytes, totalFiles, totalUsers, publicBytes, privateBytes int64) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -174,7 +270,7 @@ func (m *Metrics) GetStorageMetrics() (totalBytes, totalFiles, totalUsers, publi
 		m.publicBytesStored, m.privateBytesStored
 }
 
-// GetCacheMetrics returns cache metrics
+// GetCacheMetrics returns cache metrics.
 func (m *Metrics) GetCacheMetrics() (hits, misses map[string]int64) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -182,7 +278,7 @@ func (m *Metrics) GetCacheMetrics() (hits, misses map[string]int64) {
 	return m.cacheHits, m.cacheMisses
 }
 
-// GetAverageDuration returns the average request duration for a given endpoint
+// GetAverageDuration returns the average request duration for a given endpoint.
 func (m *Metrics) GetAverageDuration(method, path string) time.Duration {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -200,7 +296,7 @@ func (m *Metrics) GetAverageDuration(method, path string) time.Duration {
 	return sum / time.Duration(len(durations))
 }
 
-// GetPercentileDuration returns the p-th percentile duration for a given endpoint
+// GetPercentileDuration returns the p-th percentile duration for a given endpoint.
 func (m *Metrics) GetPercentileDuration(method, path string, p float64) time.Duration {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -217,102 +313,14 @@ func (m *Metrics) GetPercentileDuration(method, path string, p float64) time.Dur
 	return durations[len(durations)*int(p)/100]
 }
 
-// Handler returns an HTTP handler that exposes metrics in Prometheus format
-func (m *Metrics) Handler() http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
-
-		// Active requests
-		active := m.GetActiveRequests()
-		writeIgnoreErr(w, "# HELP file_service_active_requests Current number of active requests")
-		writeIgnoreErr(w, "# TYPE file_service_active_requests gauge")
-		writeIgnoreErr(w, "file_service_active_requests %d\n", active)
-
-		// Upload metrics
-		uploads, uploadBytes, uploadErrors := m.GetUploadMetrics()
-		writeIgnoreErr(w, "\n# HELP file_service_uploads_total Total number of file uploads")
-		writeIgnoreErr(w, "# TYPE file_service_uploads_total counter")
-		writeIgnoreErr(w, "file_service_uploads_total %d\n", uploads)
-
-		writeIgnoreErr(w, "\n# HELP file_service_upload_bytes_total Total bytes uploaded\n")
-		writeIgnoreErr(w, "# TYPE file_service_upload_bytes_total counter\n")
-		writeIgnoreErr(w, "file_service_upload_bytes_total %d\n", uploadBytes)
-
-		writeIgnoreErr(w, "\n# HELP file_service_upload_errors_total Total number of upload errors\n")
-		writeIgnoreErr(w, "# TYPE file_service_upload_errors_total counter\n")
-		writeIgnoreErr(w, "file_service_upload_errors_total %d\n", uploadErrors)
-
-		// Download metrics
-		downloads, downloadBytes, downloadErrors := m.GetDownloadMetrics()
-		writeIgnoreErr(w, "\n# HELP file_service_downloads_total Total number of file downloads\n")
-		writeIgnoreErr(w, "# TYPE file_service_downloads_total counter\n")
-		writeIgnoreErr(w, "file_service_downloads_total %d\n", downloads)
-
-		writeIgnoreErr(w, "\n# HELP file_service_download_bytes_total Total bytes downloaded\n")
-		writeIgnoreErr(w, "# TYPE file_service_download_bytes_total counter\n")
-		writeIgnoreErr(w, "file_service_download_bytes_total %d\n", downloadBytes)
-
-		writeIgnoreErr(w, "\n# HELP file_service_download_errors_total Total number of download errors\n")
-		writeIgnoreErr(w, "# TYPE file_service_download_errors_total counter\n")
-		writeIgnoreErr(w, "file_service_download_errors_total %d\n", downloadErrors)
-
-		// Storage metrics
-		totalBytes, totalFiles, totalUsers, publicBytes, privateBytes := m.GetStorageMetrics()
-		writeIgnoreErr(w, "\n# HELP file_service_storage_bytes_total Total bytes stored\n")
-		writeIgnoreErr(w, "# TYPE file_service_storage_bytes_total gauge\n")
-		writeIgnoreErr(w, "file_service_storage_bytes_total %d\n", totalBytes)
-
-		writeIgnoreErr(w, "\n# HELP file_service_storage_files_total Total files stored\n")
-		writeIgnoreErr(w, "# TYPE file_service_storage_files_total gauge\n")
-		writeIgnoreErr(w, "file_service_storage_files_total %d\n", totalFiles)
-
-		writeIgnoreErr(w, "\n# HELP file_service_storage_users_total Total users\n")
-		writeIgnoreErr(w, "# TYPE file_service_storage_users_total gauge\n")
-		writeIgnoreErr(w, "file_service_storage_users_total %d\n", totalUsers)
-
-		writeIgnoreErr(w, "\n# HELP file_service_storage_public_bytes_total Public bytes stored\n")
-		writeIgnoreErr(w, "# TYPE file_service_storage_public_bytes_total gauge\n")
-		writeIgnoreErr(w, "file_service_storage_public_bytes_total %d\n", publicBytes)
-
-		writeIgnoreErr(w, "\n# HELP file_service_storage_private_bytes_total Private bytes stored\n")
-		writeIgnoreErr(w, "# TYPE file_service_storage_private_bytes_total gauge\n")
-		writeIgnoreErr(w, "file_service_storage_private_bytes_total %d\n", privateBytes)
-
-		// Cache metrics
-		hits, misses := m.GetCacheMetrics()
-		writeIgnoreErr(w, "\n# HELP file_service_cache_hits_total Cache hits total\n")
-		writeIgnoreErr(w, "# TYPE file_service_cache_hits_total counter\n")
-		for cacheType, count := range hits {
-			writeIgnoreErr(w, "file_service_cache_hits_total{cache_type=\"%s\"} %d\n", cacheType, count)
-		}
-
-		writeIgnoreErr(w, "\n# HELP file_service_cache_misses_total Cache misses total\n")
-		writeIgnoreErr(w, "# TYPE file_service_cache_misses_total counter\n")
-		for cacheType, count := range misses {
-			writeIgnoreErr(w, "file_service_cache_misses_total{cache_type=\"%s\"} %d\n", cacheType, count)
-		}
-
-		// Request count metrics
-		requests := m.GetRequestMetrics()
-		writeIgnoreErr(w, "\n# HELP file_service_requests_total Total requests\n")
-		writeIgnoreErr(w, "# TYPE file_service_requests_total counter\n")
-		for key, count := range requests {
-			writeIgnoreErr(w, "file_service_requests_total{endpoint=\"%s\"} %d\n", key, count)
-		}
-
-		writeIgnoreErr(w, "\n# HELP file_service_up Service health status\n")
-		writeIgnoreErr(w, "# TYPE file_service_up gauge\n")
-		writeIgnoreErr(w, "file_service_up 1\n")
-	})
-}
-
-// Middleware returns middleware that records metrics for each request
+// Middleware returns middleware that records metrics for each request.
 func (m *Metrics) Middleware() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
 			start := time.Now()
-			m.RecordActiveRequest(1)
-			defer m.RecordActiveRequest(-1)
+			m.RecordActiveRequest(ctx, 1)
+			defer m.RecordActiveRequest(ctx, -1)
 
 			// Wrap response writer to capture status code
 			wrapped := &responseWriterWrapper{
@@ -323,10 +331,10 @@ func (m *Metrics) Middleware() func(http.Handler) http.Handler {
 			next.ServeHTTP(wrapped, r)
 
 			duration := time.Since(start)
-			m.RecordRequest(r.Method, r.URL.Path, duration, wrapped.statusCode)
+			m.RecordRequest(ctx, r.Method, r.URL.Path, duration, wrapped.statusCode)
 
 			if duration > 5*time.Second {
-				util.Log(r.Context()).WithFields(map[string]any{
+				util.Log(ctx).WithFields(map[string]any{
 					"duration": duration,
 					"path":     r.URL.Path,
 				}).Warn("slow request detected")

--- a/apps/default/service/metrics/metrics_test.go
+++ b/apps/default/service/metrics/metrics_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -8,8 +9,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pitabwire/frame/v2/security"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 func TestNewMetrics(t *testing.T) {
@@ -22,9 +27,10 @@ func TestNewMetrics(t *testing.T) {
 
 func TestRecordRequest(t *testing.T) {
 	m := NewMetrics()
+	ctx := context.Background()
 
-	m.RecordRequest("GET", "/api/test", 100*time.Millisecond, 200)
-	m.RecordRequest("GET", "/api/test", 150*time.Millisecond, 200)
+	m.RecordRequest(ctx, "GET", "/api/test", 100*time.Millisecond, 200)
+	m.RecordRequest(ctx, "GET", "/api/test", 150*time.Millisecond, 200)
 
 	reqMetrics := m.GetRequestMetrics()
 	assert.Equal(t, int64(2), reqMetrics["GET:/api/test"])
@@ -36,25 +42,27 @@ func TestRecordRequest(t *testing.T) {
 
 func TestRecordActiveRequest(t *testing.T) {
 	m := NewMetrics()
+	ctx := context.Background()
 
 	assert.Equal(t, int64(0), m.GetActiveRequests())
 
-	m.RecordActiveRequest(1)
+	m.RecordActiveRequest(ctx, 1)
 	assert.Equal(t, int64(1), m.GetActiveRequests())
 
-	m.RecordActiveRequest(1)
+	m.RecordActiveRequest(ctx, 1)
 	assert.Equal(t, int64(2), m.GetActiveRequests())
 
-	m.RecordActiveRequest(-1)
+	m.RecordActiveRequest(ctx, -1)
 	assert.Equal(t, int64(1), m.GetActiveRequests())
 }
 
 func TestRecordUpload(t *testing.T) {
 	m := NewMetrics()
+	ctx := context.Background()
 
-	m.RecordUpload(1024, true)
-	m.RecordUpload(2048, true)
-	m.RecordUpload(512, false)
+	m.RecordUpload(ctx, 1024, true)
+	m.RecordUpload(ctx, 2048, true)
+	m.RecordUpload(ctx, 512, false)
 
 	total, bytes, errors := m.GetUploadMetrics()
 	assert.Equal(t, int64(3), total)
@@ -64,9 +72,10 @@ func TestRecordUpload(t *testing.T) {
 
 func TestRecordDownload(t *testing.T) {
 	m := NewMetrics()
+	ctx := context.Background()
 
-	m.RecordDownload(1024, true)
-	m.RecordDownload(2048, false)
+	m.RecordDownload(ctx, 1024, true)
+	m.RecordDownload(ctx, 2048, false)
 
 	total, bytes, errors := m.GetDownloadMetrics()
 	assert.Equal(t, int64(2), total)
@@ -77,7 +86,7 @@ func TestRecordDownload(t *testing.T) {
 func TestRecordStorageStats(t *testing.T) {
 	m := NewMetrics()
 
-	m.RecordStorageStats(1000000, 100, 10, 500000, 500000)
+	m.RecordStorageStats(context.Background(), 1000000, 100, 10, 500000, 500000)
 
 	totalBytes, totalFiles, totalUsers, publicBytes, privateBytes := m.GetStorageMetrics()
 	assert.Equal(t, int64(1000000), totalBytes)
@@ -89,10 +98,11 @@ func TestRecordStorageStats(t *testing.T) {
 
 func TestRecordCacheHit(t *testing.T) {
 	m := NewMetrics()
+	ctx := context.Background()
 
-	m.RecordCacheHit("thumbnail")
-	m.RecordCacheHit("thumbnail")
-	m.RecordCacheHit("metadata")
+	m.RecordCacheHit(ctx, "thumbnail")
+	m.RecordCacheHit(ctx, "thumbnail")
+	m.RecordCacheHit(ctx, "metadata")
 
 	hits, _ := m.GetCacheMetrics()
 	assert.Equal(t, int64(2), hits["thumbnail"])
@@ -101,9 +111,10 @@ func TestRecordCacheHit(t *testing.T) {
 
 func TestRecordCacheMiss(t *testing.T) {
 	m := NewMetrics()
+	ctx := context.Background()
 
-	m.RecordCacheMiss("thumbnail")
-	m.RecordCacheMiss("metadata")
+	m.RecordCacheMiss(ctx, "thumbnail")
+	m.RecordCacheMiss(ctx, "metadata")
 
 	_, misses := m.GetCacheMetrics()
 	assert.Equal(t, int64(1), misses["thumbnail"])
@@ -112,15 +123,16 @@ func TestRecordCacheMiss(t *testing.T) {
 
 func TestGetAverageDuration(t *testing.T) {
 	m := NewMetrics()
+	ctx := context.Background()
 
 	// Test with no requests
 	avg := m.GetAverageDuration("GET", "/test")
 	assert.Equal(t, time.Duration(0), avg)
 
 	// Test with requests
-	m.RecordRequest("GET", "/test", 100*time.Millisecond, 200)
-	m.RecordRequest("GET", "/test", 200*time.Millisecond, 200)
-	m.RecordRequest("GET", "/test", 300*time.Millisecond, 200)
+	m.RecordRequest(ctx, "GET", "/test", 100*time.Millisecond, 200)
+	m.RecordRequest(ctx, "GET", "/test", 200*time.Millisecond, 200)
+	m.RecordRequest(ctx, "GET", "/test", 300*time.Millisecond, 200)
 
 	avg = m.GetAverageDuration("GET", "/test")
 	assert.Equal(t, 200*time.Millisecond, avg)
@@ -128,6 +140,7 @@ func TestGetAverageDuration(t *testing.T) {
 
 func TestGetPercentileDuration(t *testing.T) {
 	m := NewMetrics()
+	ctx := context.Background()
 
 	// Test with no requests
 	pct := m.GetPercentileDuration("GET", "/test", 50)
@@ -138,7 +151,7 @@ func TestGetPercentileDuration(t *testing.T) {
 	// 50th percentile = index 5 (6th item) = 600ms
 	// 90th percentile = index 9 (10th item) = 1000ms
 	for i := 0; i < 10; i++ {
-		m.RecordRequest("GET", "/test", time.Duration(i+1)*100*time.Millisecond, 200)
+		m.RecordRequest(ctx, "GET", "/test", time.Duration(i+1)*100*time.Millisecond, 200)
 	}
 
 	pct = m.GetPercentileDuration("GET", "/test", 50)
@@ -150,38 +163,15 @@ func TestGetPercentileDuration(t *testing.T) {
 
 func TestRequestDurationLimit(t *testing.T) {
 	m := NewMetrics()
+	ctx := context.Background()
 
 	// Add many requests to test the 1000 limit
 	for i := 0; i < 1500; i++ {
-		m.RecordRequest("GET", "/test", time.Duration(i)*time.Millisecond, 200)
+		m.RecordRequest(ctx, "GET", "/test", time.Duration(i)*time.Millisecond, 200)
 	}
 
 	reqMetrics := m.GetRequestMetrics()
 	assert.Equal(t, int64(1500), reqMetrics["GET:/test"])
-}
-
-func TestHandler(t *testing.T) {
-	m := NewMetrics()
-
-	// Record some metrics
-	m.RecordRequest("GET", "/test", 100*time.Millisecond, 200)
-	m.RecordUpload(1024, true)
-	m.RecordCacheHit("thumbnail")
-
-	handler := m.Handler()
-	require.NotNil(t, handler)
-
-	req := httptest.NewRequest("GET", "/metrics", nil)
-	w := httptest.NewRecorder()
-
-	handler.ServeHTTP(w, req)
-
-	assert.Equal(t, "text/plain; version=0.0.4", w.Header().Get("Content-Type"))
-	body := w.Body.String()
-	assert.Contains(t, body, "file_service_active_requests")
-	assert.Contains(t, body, "file_service_uploads_total")
-	assert.Contains(t, body, "file_service_cache_hits_total")
-	assert.Contains(t, body, "file_service_up")
 }
 
 func TestMiddleware(t *testing.T) {
@@ -288,37 +278,83 @@ func TestReadyCheckHandlerWithNilFunction(t *testing.T) {
 	assert.Contains(t, w.Body.String(), `"status":"ready"`)
 }
 
-func TestMetricsFormat(t *testing.T) {
+// findMetric returns the metric with the given name, or nil when absent.
+func findMetric(rm metricdata.ResourceMetrics, name string) *metricdata.Metrics {
+	for _, sm := range rm.ScopeMetrics {
+		for i := range sm.Metrics {
+			if sm.Metrics[i].Name == name {
+				return &sm.Metrics[i]
+			}
+		}
+	}
+	return nil
+}
+
+// TestMetricsTenantAttribution proves, via a ManualReader, that the ported
+// instruments keep their exact file_service_* names and automatically attach
+// tenant_id/partition_id from the context claims: one counter (cache hits,
+// with its cache_type attribute) and one gauge (active requests).
+func TestMetricsTenantAttribution(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	otel.SetMeterProvider(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+
 	m := NewMetrics()
 
-	m.RecordRequest("GET", "/api/test", 100*time.Millisecond, 200)
-	m.RecordUpload(1024, true)
-	m.RecordCacheHit("thumbnail")
+	claims := &security.AuthenticationClaims{
+		TenantID:    "tenant-files-attr",
+		PartitionID: "partition-files-attr",
+	}
+	claims.Subject = "subject-files-attr"
+	ctx := claims.ClaimsToContext(context.Background())
 
-	handler := m.Handler()
-	req := httptest.NewRequest("GET", "/metrics", nil)
-	w := httptest.NewRecorder()
-	handler.ServeHTTP(w, req)
+	m.RecordCacheHit(ctx, "thumbnail")
+	m.RecordActiveRequest(ctx, 1)
 
-	body := w.Body.String()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
 
-	// Check HELP comments
-	assert.Contains(t, body, "# HELP file_service_active_requests")
-	assert.Contains(t, body, "# HELP file_service_uploads_total")
-	assert.Contains(t, body, "# HELP file_service_downloads_total")
-	assert.Contains(t, body, "# HELP file_service_storage_bytes_total")
-	assert.Contains(t, body, "# HELP file_service_cache_hits_total")
-	assert.Contains(t, body, "# HELP file_service_requests_total")
-	assert.Contains(t, body, "# HELP file_service_up")
+	// Counter: exact name, cache_type plus tenant attributes.
+	hits := findMetric(rm, "file_service_cache_hits_total")
+	require.NotNil(t, hits, "cache hits counter must keep its metric name")
+	sum, ok := hits.Data.(metricdata.Sum[int64])
+	require.True(t, ok, "cache hits must be an int64 sum")
 
-	// Check TYPE comments
-	assert.Contains(t, body, "# TYPE file_service_active_requests gauge")
-	assert.Contains(t, body, "# TYPE file_service_uploads_total counter")
-	assert.Contains(t, body, "# TYPE file_service_downloads_total counter")
-	assert.Contains(t, body, "# TYPE file_service_storage_bytes_total gauge")
-	assert.Contains(t, body, "# TYPE file_service_cache_hits_total counter")
-	assert.Contains(t, body, "# TYPE file_service_requests_total counter")
-	assert.Contains(t, body, "# TYPE file_service_up gauge")
+	var counterMatched bool
+	for _, dp := range sum.DataPoints {
+		tenant, hasTenant := dp.Attributes.Value("tenant_id")
+		if !hasTenant || tenant.AsString() != "tenant-files-attr" {
+			continue
+		}
+		counterMatched = true
+		partition, hasPartition := dp.Attributes.Value("partition_id")
+		require.True(t, hasPartition, "partition_id must accompany tenant_id")
+		require.Equal(t, "partition-files-attr", partition.AsString())
+		cacheType, hasCacheType := dp.Attributes.Value("cache_type")
+		require.True(t, hasCacheType, "cache_type attribute must be preserved")
+		require.Equal(t, "thumbnail", cacheType.AsString())
+		require.Equal(t, int64(1), dp.Value)
+	}
+	require.True(t, counterMatched, "expected a cache hit datapoint attributed to tenant-files-attr")
+
+	// Gauge: exact name with tenant attribution and the recorded value.
+	active := findMetric(rm, "file_service_active_requests")
+	require.NotNil(t, active, "active requests gauge must keep its metric name")
+	gauge, ok := active.Data.(metricdata.Gauge[int64])
+	require.True(t, ok, "active requests must be an int64 gauge")
+
+	var gaugeMatched bool
+	for _, dp := range gauge.DataPoints {
+		tenant, hasTenant := dp.Attributes.Value("tenant_id")
+		if !hasTenant || tenant.AsString() != "tenant-files-attr" {
+			continue
+		}
+		gaugeMatched = true
+		partition, hasPartition := dp.Attributes.Value("partition_id")
+		require.True(t, hasPartition, "partition_id must accompany tenant_id")
+		require.Equal(t, "partition-files-attr", partition.AsString())
+		require.Equal(t, int64(1), dp.Value)
+	}
+	require.True(t, gaugeMatched, "expected an active requests datapoint attributed to tenant-files-attr")
 }
 
 func TestResponseWriterWrapper(t *testing.T) {


### PR DESCRIPTION
## Summary
- Port `apps/default/service/metrics/metrics.go` from the hand-rolled in-memory registry + bespoke Prometheus text handler to OpenTelemetry instruments created through frame's tenant-scoped `telemetry.NewBusinessMetrics` factory.
- Every measurement now automatically carries `tenant_id`/`partition_id` derived from the context's security claims.
- Pin `github.com/pitabwire/frame` to **v1.98.4** (first release containing `telemetry.NewBusinessMetrics`).

## Metric names — preserved exactly
- Counters: `file_service_uploads_total`, `file_service_upload_bytes_total`, `file_service_upload_errors_total`, `file_service_downloads_total`, `file_service_download_bytes_total`, `file_service_download_errors_total`, `file_service_cache_hits_total`/`file_service_cache_misses_total` (with `cache_type`), `file_service_requests_total` (with `endpoint`).
- Gauges: `file_service_active_requests`, `file_service_storage_bytes_total`, `file_service_storage_files_total`, `file_service_storage_users_total`, `file_service_storage_public_bytes_total`, `file_service_storage_private_bytes_total` — recorded exactly where the values were previously set (middleware delta, upload accounting, `RecordStorageStats`).

## API surface
The `Metrics` struct keeps its public API (`Record*`, `Get*`, `Middleware`, health/ready handlers) wrapping the new instruments; `Record*` methods gain a `context.Context` first parameter so tenant attribution flows from claims. Internal tallies are retained to back gauge values and the `Get*` accessors.

## Removed: bespoke Prometheus `Handler()`
`grep` confirms nothing in the repo imports the metrics package or references the handler endpoint — it was dead code. Metrics are exported through the service's OTel pipeline instead, so the handler (and its synthetic `file_service_up` series) is removed rather than kept on life support.

## Testing
- New `TestMetricsTenantAttribution` (ManualReader) proves exact names + automatic `tenant_id`/`partition_id` for one counter (`file_service_cache_hits_total`, with `cache_type`) and one gauge (`file_service_active_requests`).
- Full suite on top of the RLS-exercising test base (#706): `go test ./... -count=1` — all green (25 packages ok).
- `go build ./...` clean; `golangci-lint` 0 issues on the changed package.