### PR TITLE
feat(ui): add gate-backed activity analytics to the storage dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ apps/default/service/handler/routing/testdata/tmp/
 .tmp/
 WORK_STATE.md
 .claude/
+
+# Local-only pub dependency overrides (path overrides for unpublished packages)
+pubspec_overrides.yaml

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 0.3.0
+
+- `StorageDashboardScreen` keeps inventory totals on the `GetStorageStats`
+  entity API and now adds a gate-backed Activity section: upload/download
+  KPIs and trends, transferred bytes, and a derived cache hit ratio sourced
+  from the thesa analytics gate via `antinvestor_ui_core`'s
+  `analyticsDataSourceProvider` (`file_service_*` business metrics).
+- Added `filesAnalyticsSpec` (a `ServiceAnalyticsSpec`) for host apps to
+  register on their `ThesaAnalyticsDataSource`, `cacheHitRatioPercent` for
+  the hits/misses ratio, and `analyticsGateMessage` for friendly gate error
+  states (400 allowlist, 403 unscoped, 5xx backend down).
+- Requires `antinvestor_ui_core` >= 0.5.0 (unpublished; use a local path
+  override during development).
+
 ## 0.1.1
 
 - Migrate providers to Riverpod 3.x Notifier, fix lint warnings and deprecations

--- a/ui/lib/antinvestor_ui_files.dart
+++ b/ui/lib/antinvestor_ui_files.dart
@@ -4,6 +4,9 @@
 /// browsing, access control, versioning, and retention management.
 library;
 
+// Analytics
+export 'src/analytics/files_analytics.dart';
+
 // Providers
 export 'src/providers/files_transport_provider.dart';
 export 'src/providers/files_providers.dart';

--- a/ui/lib/src/analytics/files_analytics.dart
+++ b/ui/lib/src/analytics/files_analytics.dart
@@ -1,0 +1,122 @@
+import 'package:antinvestor_ui_core/antinvestor_ui_core.dart';
+import 'package:flutter/material.dart';
+
+/// Metric names emitted by service-files' business instrumentation
+/// (`file_service_*` counters in apps/default/service/metrics/metrics.go).
+const String fileUploadsMetric = 'file_service_uploads_total';
+const String fileDownloadsMetric = 'file_service_downloads_total';
+const String fileUploadBytesMetric = 'file_service_upload_bytes_total';
+const String fileDownloadBytesMetric = 'file_service_download_bytes_total';
+const String fileCacheHitsMetric = 'file_service_cache_hits_total';
+const String fileCacheMissesMetric = 'file_service_cache_misses_total';
+
+/// KPI keys used by [filesAnalyticsSpec].
+const String fileCacheHitsKpiKey = 'cache_hits';
+const String fileCacheMissesKpiKey = 'cache_misses';
+
+/// Analytics catalog for the files service, consumed by the thesa-gated
+/// metrics pipeline.
+///
+/// Host apps register this spec on their [ThesaAnalyticsDataSource]:
+///
+/// ```dart
+/// analyticsDataSourceProvider.overrideWith(
+///   (ref) => ThesaAnalyticsDataSource(transport, specs: [filesAnalyticsSpec]),
+/// );
+/// ```
+///
+/// Inventory totals (file counts, stored bytes, users) stay on the entity
+/// API (`GetStorageStats`); only activity rates and trends are queried
+/// through the gate. Tenant scoping is injected server-side from the
+/// caller's JWT; no tenant/partition filters are declared (or ever sent).
+const ServiceAnalyticsSpec filesAnalyticsSpec = ServiceAnalyticsSpec(
+  service: 'files',
+  kpis: [
+    KpiSpec(
+      'uploads',
+      label: 'Uploads',
+      metric: fileUploadsMetric,
+      unit: 'count',
+      icon: Icons.upload_outlined,
+    ),
+    KpiSpec(
+      'downloads',
+      label: 'Downloads',
+      metric: fileDownloadsMetric,
+      unit: 'count',
+      icon: Icons.download_outlined,
+    ),
+    KpiSpec(
+      'upload_bytes',
+      label: 'Data uploaded',
+      metric: fileUploadBytesMetric,
+      unit: 'bytes',
+      icon: Icons.cloud_upload_outlined,
+    ),
+    KpiSpec(
+      'download_bytes',
+      label: 'Data downloaded',
+      metric: fileDownloadBytesMetric,
+      unit: 'bytes',
+      icon: Icons.cloud_download_outlined,
+    ),
+    KpiSpec(
+      fileCacheHitsKpiKey,
+      label: 'Cache hits',
+      metric: fileCacheHitsMetric,
+      unit: 'count',
+      icon: Icons.bolt_outlined,
+    ),
+    KpiSpec(
+      fileCacheMissesKpiKey,
+      label: 'Cache misses',
+      metric: fileCacheMissesMetric,
+      unit: 'count',
+      icon: Icons.bolt_outlined,
+    ),
+  ],
+  charts: [
+    ChartConfig.timeSeries(fileUploadsMetric, label: 'Uploads'),
+    ChartConfig.timeSeries(fileDownloadsMetric, label: 'Downloads'),
+    ChartConfig.timeSeries(fileUploadBytesMetric, label: 'Data uploaded'),
+    ChartConfig.timeSeries(fileDownloadBytesMetric, label: 'Data downloaded'),
+  ],
+);
+
+/// Derives the cache hit ratio (percent) from the gate-fetched KPI values.
+///
+/// The gate has no client-facing ratio query, so the ratio is computed from
+/// the `file_service_cache_hits_total` / `file_service_cache_misses_total`
+/// scalars. Returns null when either value is missing or there was no cache
+/// traffic in the window.
+double? cacheHitRatioPercent(List<MetricValue> metrics) {
+  double? hits;
+  double? misses;
+  for (final m in metrics) {
+    if (m.key == fileCacheHitsKpiKey) hits = m.value;
+    if (m.key == fileCacheMissesKpiKey) misses = m.value;
+  }
+  if (hits == null || misses == null) return null;
+  final total = hits + misses;
+  if (total <= 0) return null;
+  return (hits / total) * 100;
+}
+
+/// Maps analytics gate failures to short, user-facing messages.
+///
+/// The gate's error contract: 400 -> metric rejected by the server-side
+/// allowlist, 403 -> caller's JWT carries no tenant scope, 5xx -> metrics
+/// backend unreachable.
+String analyticsGateMessage(Object error) {
+  if (error is AnalyticsQueryException) {
+    return switch (error.statusCode) {
+      400 => 'This metric is not available from the analytics gate.',
+      403 => 'Analytics are not available for your current sign-in scope.',
+      >= 500 =>
+        'The analytics backend is temporarily unavailable. '
+            'Please try again shortly.',
+      _ => 'Could not load analytics (HTTP ${error.statusCode}).',
+    };
+  }
+  return 'Could not load analytics.';
+}

--- a/ui/lib/src/screens/storage_dashboard_screen.dart
+++ b/ui/lib/src/screens/storage_dashboard_screen.dart
@@ -1,43 +1,74 @@
 import 'package:antinvestor_api_files/antinvestor_api_files.dart';
-import 'package:antinvestor_ui_core/widgets/error_helpers.dart';
+import 'package:antinvestor_ui_core/antinvestor_ui_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../analytics/files_analytics.dart';
 import '../providers/files_providers.dart';
 import '../widgets/file_preview_card.dart';
 import '../widgets/storage_usage_bar.dart';
 
-/// Dashboard screen showing storage usage statistics.
-class StorageDashboardScreen extends ConsumerWidget {
+/// Dashboard screen showing storage inventory and transfer activity.
+///
+/// Inventory totals (file count, stored bytes, users) stay on the entity
+/// API via `GetStorageStats`. Activity KPIs and trends (uploads, downloads,
+/// transferred bytes, cache hit ratio) come from the thesa analytics gate
+/// ([analyticsDataSourceProvider]) using the `file_service_*` business
+/// metrics. Tenant scoping is injected server-side; this screen never sends
+/// tenant or partition filters.
+class StorageDashboardScreen extends ConsumerStatefulWidget {
   const StorageDashboardScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final theme = Theme.of(context);
-    final asyncStats = ref.watch(getStorageStatsProvider);
+  ConsumerState<StorageDashboardScreen> createState() =>
+      _StorageDashboardScreenState();
+}
 
-    return asyncStats.when(
-      loading: () => const Center(child: CircularProgressIndicator()),
-      error: (error, _) => Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(Icons.error_outline, size: 48, color: theme.colorScheme.error),
-            const SizedBox(height: 16),
-            Text(friendlyError(error), style: theme.textTheme.bodyLarge),
-            const SizedBox(height: 16),
-            FilledButton.tonal(
-              onPressed: () => ref.invalidate(getStorageStatsProvider),
-              child: const Text('Retry'),
-            ),
-          ],
-        ),
-      ),
-      data: (stats) => _buildDashboard(theme, stats),
-    );
+class _StorageDashboardScreenState
+    extends ConsumerState<StorageDashboardScreen> {
+  AnalyticsTimeRange _timeRange = AnalyticsTimeRange.last30Days();
+
+  static const String _service = 'files';
+
+  ServiceMetricsParams get _metricsParams =>
+      ServiceMetricsParams(_service, timeRange: _timeRange);
+
+  ServiceTimeSeriesParams _seriesParams(String metric) =>
+      ServiceTimeSeriesParams(_service, metric, timeRange: _timeRange);
+
+  void _refresh() {
+    ref.invalidate(serviceMetricsProvider(_metricsParams));
+    for (final metric in const [
+      fileUploadsMetric,
+      fileDownloadsMetric,
+      fileUploadBytesMetric,
+      fileDownloadBytesMetric,
+    ]) {
+      ref.invalidate(serviceTimeSeriesProvider(_seriesParams(metric)));
+    }
   }
 
-  Widget _buildDashboard(ThemeData theme, GetStorageStatsResponse stats) {
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final asyncStats = ref.watch(getStorageStatsProvider);
+    final metricsAsync = ref.watch(serviceMetricsProvider(_metricsParams));
+    final isDesktop = AppBreakpoints.isDesktop(
+      MediaQuery.sizeOf(context).width,
+    );
+
+    final transferCountsCard = _ChartCard(
+      title: 'Transfer activity',
+      subtitle: 'Uploads and downloads over time',
+      child: _buildDualSeries(fileUploadsMetric, fileDownloadsMetric),
+    );
+
+    final transferBytesCard = _ChartCard(
+      title: 'Transfer volume',
+      subtitle: 'Bytes uploaded and downloaded over time',
+      child: _buildDualSeries(fileUploadBytesMetric, fileDownloadBytesMetric),
+    );
+
     return SingleChildScrollView(
       padding: const EdgeInsets.all(24),
       child: Column(
@@ -55,64 +86,303 @@ class StorageDashboardScreen extends ConsumerWidget {
                   letterSpacing: -0.3,
                 ),
               ),
+              const Spacer(),
+              IconButton(
+                icon: const Icon(Icons.refresh),
+                tooltip: 'Refresh',
+                onPressed: () {
+                  ref.invalidate(getStorageStatsProvider);
+                  _refresh();
+                },
+              ),
             ],
           ),
           const SizedBox(height: 24),
 
-          // Overall usage bar
-          Card(
-            child: Padding(
-              padding: const EdgeInsets.all(20),
-              child: StorageUsageBar(
-                usedBytes: stats.totalBytes.toInt(),
-                totalBytes: stats.totalBytes.toInt(),
-                label: 'Total Storage',
+          // Inventory (entity API)
+          asyncStats.when(
+            loading: () => const SizedBox(
+              height: 160,
+              child: Center(child: CircularProgressIndicator()),
+            ),
+            error: (error, _) => Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    Icons.error_outline,
+                    size: 48,
+                    color: theme.colorScheme.error,
+                  ),
+                  const SizedBox(height: 16),
+                  Text(friendlyError(error), style: theme.textTheme.bodyLarge),
+                  const SizedBox(height: 16),
+                  FilledButton.tonal(
+                    onPressed: () => ref.invalidate(getStorageStatsProvider),
+                    child: const Text('Retry'),
+                  ),
+                ],
               ),
+            ),
+            data: (stats) => _InventorySection(theme: theme, stats: stats),
+          ),
+          const SizedBox(height: 24),
+
+          // Activity (thesa analytics gate)
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  'Activity',
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+              SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                reverse: true,
+                child: TimeRangeSelector(
+                  value: _timeRange,
+                  onChanged: (range) => setState(() => _timeRange = range),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          metricsAsync.when(
+            data: (metrics) => metrics.isEmpty
+                ? const AnalyticsGateErrorCard(
+                    message:
+                        'Analytics are not configured for the files '
+                        'service in this app.',
+                  )
+                : MetricsRow(metrics: _displayMetrics(metrics)),
+            loading: () => const MetricsRow(metrics: [], isLoading: true),
+            error: (e, _) => AnalyticsGateErrorCard(
+              message: analyticsGateMessage(e),
+              onRetry: _refresh,
+            ),
+          ),
+          const SizedBox(height: 20),
+          if (isDesktop)
+            IntrinsicHeight(
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Expanded(child: transferCountsCard),
+                  const SizedBox(width: 16),
+                  Expanded(child: transferBytesCard),
+                ],
+              ),
+            )
+          else ...[
+            transferCountsCard,
+            const SizedBox(height: 16),
+            transferBytesCard,
+          ],
+        ],
+      ),
+    );
+  }
+
+  /// KPI cards shown to the user: transfer counters and volumes plus the
+  /// derived cache hit ratio (raw hit/miss scalars are folded into it).
+  List<MetricValue> _displayMetrics(List<MetricValue> metrics) {
+    final visible = [
+      for (final m in metrics)
+        if (m.key != fileCacheHitsKpiKey && m.key != fileCacheMissesKpiKey) m,
+    ];
+    final ratio = cacheHitRatioPercent(metrics);
+    if (ratio != null) {
+      visible.add(
+        MetricValue(
+          key: 'cache_hit_ratio',
+          label: 'Cache hit ratio',
+          value: ratio,
+          unit: 'percent',
+          icon: Icons.bolt_outlined,
+        ),
+      );
+    }
+    return visible;
+  }
+
+  /// Renders two gate time series (e.g. uploads vs downloads) on one chart.
+  Widget _buildDualSeries(String metricA, String metricB) {
+    final asyncA = ref.watch(serviceTimeSeriesProvider(_seriesParams(metricA)));
+    final asyncB = ref.watch(serviceTimeSeriesProvider(_seriesParams(metricB)));
+
+    final error = asyncA.error ?? asyncB.error;
+    if (error != null) {
+      return AnalyticsGateErrorCard(
+        message: analyticsGateMessage(error),
+        onRetry: _refresh,
+      );
+    }
+    if (asyncA.isLoading || asyncB.isLoading) {
+      return const SizedBox(
+        height: 240,
+        child: Center(child: CircularProgressIndicator()),
+      );
+    }
+    return TimeSeriesChart(
+      series: [...?asyncA.value, ...?asyncB.value],
+      granularity: _timeRange.granularity,
+    );
+  }
+}
+
+/// Friendly inline error/empty card for analytics gate failures.
+class AnalyticsGateErrorCard extends StatelessWidget {
+  const AnalyticsGateErrorCard({
+    super.key,
+    required this.message,
+    this.onRetry,
+  });
+
+  final String message;
+  final VoidCallback? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: cs.errorContainer.withValues(alpha: 0.25),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.insights_outlined, color: cs.error, size: 20),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              message,
+              style: TextStyle(color: cs.error, fontSize: 13),
+            ),
+          ),
+          if (onRetry != null) ...[
+            const SizedBox(width: 8),
+            TextButton(onPressed: onRetry, child: const Text('Retry')),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+/// Inventory cards backed by the `GetStorageStats` entity API.
+class _InventorySection extends StatelessWidget {
+  const _InventorySection({required this.theme, required this.stats});
+
+  final ThemeData theme;
+  final GetStorageStatsResponse stats;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        // Overall usage bar
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(20),
+            child: StorageUsageBar(
+              usedBytes: stats.totalBytes.toInt(),
+              totalBytes: stats.totalBytes.toInt(),
+              label: 'Total Storage',
+            ),
+          ),
+        ),
+        const SizedBox(height: 16),
+
+        // Summary stat cards
+        Row(
+          children: [
+            Expanded(
+              child: _StatCard(
+                theme: theme,
+                icon: Icons.folder,
+                iconColor: theme.colorScheme.primary,
+                label: 'Total Files',
+                value: '${stats.totalFiles}',
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: _StatCard(
+                theme: theme,
+                icon: Icons.data_usage,
+                iconColor: Colors.teal,
+                label: 'Total Size',
+                value: FilePreviewCard.formatFileSize(stats.totalBytes.toInt()),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        Row(
+          children: [
+            Expanded(
+              child: _StatCard(
+                theme: theme,
+                icon: Icons.people,
+                iconColor: Colors.green,
+                label: 'Total Users',
+                value: '${stats.totalUsers}',
+              ),
+            ),
+            const SizedBox(width: 12),
+            const Expanded(child: SizedBox.shrink()),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _ChartCard extends StatelessWidget {
+  const _ChartCard({
+    required this.title,
+    required this.subtitle,
+    required this.child,
+  });
+
+  final String title;
+  final String subtitle;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: cs.surface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: cs.outlineVariant),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            subtitle,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: cs.onSurfaceVariant,
             ),
           ),
           const SizedBox(height: 16),
-
-          // Summary stat cards
-          Row(
-            children: [
-              Expanded(
-                child: _StatCard(
-                  theme: theme,
-                  icon: Icons.folder,
-                  iconColor: theme.colorScheme.primary,
-                  label: 'Total Files',
-                  value: '${stats.totalFiles}',
-                ),
-              ),
-              const SizedBox(width: 12),
-              Expanded(
-                child: _StatCard(
-                  theme: theme,
-                  icon: Icons.data_usage,
-                  iconColor: Colors.teal,
-                  label: 'Total Size',
-                  value: FilePreviewCard.formatFileSize(
-                      stats.totalBytes.toInt()),
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 12),
-          Row(
-            children: [
-              Expanded(
-                child: _StatCard(
-                  theme: theme,
-                  icon: Icons.people,
-                  iconColor: Colors.green,
-                  label: 'Total Users',
-                  value: '${stats.totalUsers}',
-                ),
-              ),
-              const SizedBox(width: 12),
-              const Expanded(child: SizedBox.shrink()),
-            ],
-          ),
+          child,
         ],
       ),
     );

--- a/ui/pubspec.yaml
+++ b/ui/pubspec.yaml
@@ -1,7 +1,7 @@
 name: antinvestor_ui_files
 description: >
   File management UI library for Antinvestor. Upload, browse, access control, versioning.
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/antinvestor/service-files
 homepage: https://github.com/antinvestor/service-files/tree/main/ui
 issue_tracker: https://github.com/antinvestor/service-files/issues
@@ -18,7 +18,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  antinvestor_ui_core: ^0.2.0
+  # 0.5.0 ships the thesa-gated analytics pipeline (ServiceAnalyticsSpec,
+  # ThesaAnalyticsDataSource). Not on pub.dev yet -- develop against the
+  # local checkout via the gitignored pubspec_overrides.yaml.
+  antinvestor_ui_core: ^0.5.0
   antinvestor_api_files: ^1.54.0
   antinvestor_api_common: ^1.52.0
   connectrpc: ^1.0.0
@@ -32,6 +35,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
+  http: ^1.6.0
 
 flutter:
   uses-material-design: true

--- a/ui/test/_helpers/fake_analytics_transport.dart
+++ b/ui/test/_helpers/fake_analytics_transport.dart
@@ -1,0 +1,32 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+/// Recording fake for the [AnalyticsTransport] used by
+/// `ThesaAnalyticsDataSource` in tests.
+///
+/// Captures every POSTed path + decoded JSON body and replies either via
+/// [handler] or with an empty success payload appropriate for the endpoint.
+class FakeAnalyticsTransport {
+  /// Every request made through this transport, in order.
+  final List<({String path, Map<String, dynamic> body})> calls = [];
+
+  /// Optional per-request response factory. When null, the transport
+  /// returns zero/empty payloads with HTTP 200.
+  http.Response Function(String path, Map<String, dynamic> body)? handler;
+
+  Future<http.Response> call(String path, {Object? body}) async {
+    final decoded = json.decode(body! as String) as Map<String, dynamic>;
+    calls.add((path: path, body: decoded));
+    final h = handler;
+    if (h != null) return h(path, decoded);
+    return http.Response(json.encode(_emptyPayloadFor(path)), 200);
+  }
+
+  static Map<String, dynamic> _emptyPayloadFor(String path) {
+    if (path.endsWith('/scalar')) return {'value': 0};
+    if (path.endsWith('/timeseries')) return {'points': <Object>[]};
+    if (path.endsWith('/grouped')) return {'segments': <Object>[]};
+    return {'items': <Object>[]};
+  }
+}

--- a/ui/test/analytics/files_analytics_contract_test.dart
+++ b/ui/test/analytics/files_analytics_contract_test.dart
@@ -1,0 +1,170 @@
+import 'dart:convert';
+
+import 'package:antinvestor_ui_core/antinvestor_ui_core.dart';
+import 'package:antinvestor_ui_files/antinvestor_ui_files.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+
+import '../_helpers/fake_analytics_transport.dart';
+
+void main() {
+  final timeRange = AnalyticsTimeRange(
+    start: DateTime.utc(2026, 1, 1),
+    end: DateTime.utc(2026, 1, 31),
+    granularity: TimeGranularity.day,
+  );
+  const wireTimeRange = {
+    'start': '2026-01-01T00:00:00.000Z',
+    'end': '2026-01-31T00:00:00.000Z',
+  };
+
+  late FakeAnalyticsTransport transport;
+  late ThesaAnalyticsDataSource dataSource;
+
+  setUp(() {
+    transport = FakeAnalyticsTransport();
+    dataSource = ThesaAnalyticsDataSource(
+      transport.call,
+      specs: const [filesAnalyticsSpec],
+    );
+  });
+
+  test('KPI fetch posts one exact scalar body per declared metric', () async {
+    await dataSource.getMetrics('files', timeRange: timeRange);
+
+    expect(
+      transport.calls.map((c) => c.path),
+      everyElement('/api/analytics/query/scalar'),
+    );
+    expect(transport.calls.map((c) => c.body), [
+      for (final metric in [
+        'file_service_uploads_total',
+        'file_service_downloads_total',
+        'file_service_upload_bytes_total',
+        'file_service_download_bytes_total',
+        'file_service_cache_hits_total',
+        'file_service_cache_misses_total',
+      ])
+        {'metric': metric, 'aggregation': 'sum', 'time_range': wireTimeRange},
+    ]);
+  });
+
+  test('activity trends post exact timeseries bodies with step', () async {
+    for (final metric in [
+      fileUploadsMetric,
+      fileDownloadsMetric,
+      fileUploadBytesMetric,
+      fileDownloadBytesMetric,
+    ]) {
+      transport.calls.clear();
+      await dataSource.getTimeSeries('files', metric, timeRange: timeRange);
+
+      expect(transport.calls, hasLength(1));
+      expect(transport.calls.single.path, '/api/analytics/query/timeseries');
+      expect(transport.calls.single.body, {
+        'metric': metric,
+        'aggregation': 'sum',
+        'time_range': wireTimeRange,
+        'step': 'day',
+      });
+    }
+  });
+
+  test('no request ever carries tenant or partition filters', () async {
+    await dataSource.getMetrics('files', timeRange: timeRange);
+    await dataSource.getTimeSeries(
+      'files',
+      fileUploadsMetric,
+      timeRange: timeRange,
+    );
+
+    for (final call in transport.calls) {
+      final filters =
+          (call.body['filters'] as Map<String, dynamic>?) ?? const {};
+      expect(filters.keys, isNot(contains('tenant_id')));
+      expect(filters.keys, isNot(contains('partition_id')));
+    }
+  });
+
+  test('gate errors surface status code and server message', () async {
+    transport.handler = (path, body) =>
+        http.Response(json.encode({'error': 'no tenant scope'}), 403);
+
+    await expectLater(
+      dataSource.getMetrics('files', timeRange: timeRange),
+      throwsA(
+        isA<AnalyticsQueryException>()
+            .having((e) => e.statusCode, 'statusCode', 403)
+            .having((e) => e.message, 'message', 'no tenant scope'),
+      ),
+    );
+  });
+
+  group('cacheHitRatioPercent', () {
+    MetricValue metric(String key, double value) =>
+        MetricValue(key: key, label: key, value: value);
+
+    test('derives the ratio from hits and misses', () {
+      expect(
+        cacheHitRatioPercent([
+          metric('cache_hits', 75),
+          metric('cache_misses', 25),
+        ]),
+        75.0,
+      );
+    });
+
+    test('returns null without cache traffic', () {
+      expect(
+        cacheHitRatioPercent([
+          metric('cache_hits', 0),
+          metric('cache_misses', 0),
+        ]),
+        isNull,
+      );
+    });
+
+    test('returns null when either scalar is missing', () {
+      expect(cacheHitRatioPercent([metric('cache_hits', 10)]), isNull);
+      expect(cacheHitRatioPercent(const []), isNull);
+    });
+  });
+
+  test('analyticsGateMessage maps gate statuses to friendly text', () {
+    const path = '/api/analytics/query/scalar';
+    expect(
+      analyticsGateMessage(
+        const AnalyticsQueryException(
+          statusCode: 400,
+          message: 'metric not allowed',
+          path: path,
+        ),
+      ),
+      'This metric is not available from the analytics gate.',
+    );
+    expect(
+      analyticsGateMessage(
+        const AnalyticsQueryException(
+          statusCode: 403,
+          message: 'no tenant scope',
+          path: path,
+        ),
+      ),
+      'Analytics are not available for your current sign-in scope.',
+    );
+    expect(
+      analyticsGateMessage(
+        const AnalyticsQueryException(
+          statusCode: 503,
+          message: 'backend down',
+          path: path,
+        ),
+      ),
+      contains('temporarily unavailable'),
+    );
+    expect(
+      analyticsGateMessage(StateError('boom')),
+      'Could not load analytics.',
+    );
+  });
+}

--- a/ui/test/screens/storage_dashboard_screen_test.dart
+++ b/ui/test/screens/storage_dashboard_screen_test.dart
@@ -1,0 +1,148 @@
+import 'dart:convert';
+
+import 'package:antinvestor_api_files/antinvestor_api_files.dart';
+import 'package:antinvestor_ui_core/antinvestor_ui_core.dart';
+import 'package:antinvestor_ui_files/antinvestor_ui_files.dart';
+import 'package:fixnum/fixnum.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+
+import '../_helpers/fake_analytics_transport.dart';
+
+void main() {
+  late FakeAnalyticsTransport transport;
+
+  setUp(() {
+    transport = FakeAnalyticsTransport();
+  });
+
+  GetStorageStatsResponse storageStats() => GetStorageStatsResponse()
+    ..totalFiles = Int64(321)
+    ..totalBytes = Int64(5 * 1024 * 1024)
+    ..totalUsers = Int64(12);
+
+  Future<void> pumpDashboard(
+    WidgetTester tester, {
+    Future<GetStorageStatsResponse> Function()? stats,
+  }) async {
+    tester.view.physicalSize = const Size(1600, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(
+      ProviderScope(
+        // Disable Riverpod's automatic retry so failed gate queries settle
+        // in their error state instead of flipping back to loading.
+        retry: (retryCount, error) => null,
+        overrides: [
+          getStorageStatsProvider.overrideWith(
+            (ref) => stats != null ? stats() : Future.value(storageStats()),
+          ),
+          analyticsDataSourceProvider.overrideWithValue(
+            ThesaAnalyticsDataSource(
+              transport.call,
+              specs: const [filesAnalyticsSpec],
+            ),
+          ),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(body: StorageDashboardScreen()),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('keeps inventory totals from the entity API', (tester) async {
+    await pumpDashboard(tester);
+
+    expect(find.text('Total Files'), findsOneWidget);
+    expect(find.text('321'), findsOneWidget);
+    expect(find.text('Total Users'), findsOneWidget);
+    expect(find.text('12'), findsOneWidget);
+  });
+
+  testWidgets('renders gate-backed activity KPIs with derived cache ratio', (
+    tester,
+  ) async {
+    transport.handler = (path, body) {
+      if (!path.endsWith('/scalar')) {
+        return http.Response(json.encode({'points': <Object>[]}), 200);
+      }
+      final value = switch (body['metric']) {
+        'file_service_uploads_total' => 42,
+        'file_service_downloads_total' => 87,
+        'file_service_upload_bytes_total' => 2048,
+        'file_service_download_bytes_total' => 4096,
+        'file_service_cache_hits_total' => 75,
+        'file_service_cache_misses_total' => 25,
+        _ => 0,
+      };
+      return http.Response(json.encode({'value': value}), 200);
+    };
+
+    await pumpDashboard(tester);
+
+    expect(find.text('Uploads'), findsAtLeastNWidgets(1));
+    expect(find.text('42'), findsOneWidget);
+    expect(find.text('Downloads'), findsAtLeastNWidgets(1));
+    expect(find.text('87'), findsOneWidget);
+    expect(find.text('Data uploaded'), findsAtLeastNWidgets(1));
+    expect(find.text('2.0 KB'), findsOneWidget);
+    expect(find.text('Data downloaded'), findsAtLeastNWidgets(1));
+    expect(find.text('4.1 KB'), findsOneWidget);
+    expect(find.text('Cache hit ratio'), findsOneWidget);
+    expect(find.text('75.0%'), findsOneWidget);
+    // Raw hit/miss scalars are folded into the ratio card.
+    expect(find.text('Cache hits'), findsNothing);
+    expect(find.text('Cache misses'), findsNothing);
+  });
+
+  testWidgets('omits the cache ratio card without cache traffic', (
+    tester,
+  ) async {
+    await pumpDashboard(tester);
+
+    expect(find.text('Cache hit ratio'), findsNothing);
+  });
+
+  testWidgets('shows empty chart states when the gate has no data', (
+    tester,
+  ) async {
+    await pumpDashboard(tester);
+
+    // Transfer activity and transfer volume both report no data.
+    expect(find.text('No data'), findsNWidgets(2));
+  });
+
+  for (final (status, fragment) in [
+    (400, 'not available from the analytics gate'),
+    (403, 'not available for your current sign-in scope'),
+    (503, 'temporarily unavailable'),
+  ]) {
+    testWidgets('renders friendly state for gate HTTP $status', (tester) async {
+      transport.handler = (path, body) =>
+          http.Response(json.encode({'error': 'gate says no'}), status);
+
+      await pumpDashboard(tester);
+
+      // KPI row plus both charts surface the same friendly message, while
+      // entity-backed inventory still renders.
+      expect(find.textContaining(fragment), findsNWidgets(3));
+      expect(find.textContaining('gate says no'), findsNothing);
+      expect(find.text('Total Files'), findsOneWidget);
+    });
+  }
+
+  testWidgets('inventory errors stay independent of the gate', (tester) async {
+    await pumpDashboard(
+      tester,
+      stats: () => Future.error(Exception('stats backend down')),
+    );
+
+    expect(find.text('Retry'), findsAtLeastNWidgets(1));
+    // Gate-backed activity still renders its empty charts.
+    expect(find.text('No data'), findsNWidgets(2));
+  });
+}


### PR DESCRIPTION
## Summary
Converts `StorageDashboardScreen` to the standardized thesa-gated metrics pipeline from `antinvestor_ui_core` 0.5.0, while keeping inventory on the entity API.

- Inventory (Total Files / Total Size / Total Users) stays on `GetStorageStats`
- New Activity section sourced from the gate: upload/download counts, transferred bytes, and trends, with a selectable time range
- Cache hit ratio derived client-side from `file_service_cache_hits_total` vs `file_service_cache_misses_total` (the gate exposes no client-facing ratio query)
- Exports `filesAnalyticsSpec` (`ServiceAnalyticsSpec`) for host apps to register on their `ThesaAnalyticsDataSource`
- Friendly gate error states: 400 (allowlist), 403 (unscoped), 5xx (backend down), independent of the entity-backed inventory; tenant/partition filters are never sent client-side

## KPI -> metric mapping
| KPI | Metric | Aggregation |
| --- | --- | --- |
| Uploads | `file_service_uploads_total` | sum |
| Downloads | `file_service_downloads_total` | sum |
| Data uploaded | `file_service_upload_bytes_total` | sum |
| Data downloaded | `file_service_download_bytes_total` | sum |
| Cache hit ratio | `file_service_cache_hits_total` / (`...hits` + `file_service_cache_misses_total`) | derived |

Charts: "Transfer activity" overlays the uploads/downloads timeseries; "Transfer volume" overlays the byte counters.

## Notes
- `antinvestor_ui_core: ^0.5.0` is not published yet (pub.dev has 0.4.1); CI for UI packages is lenient/non-blocking. Local development uses a gitignored `pubspec_overrides.yaml` path override against the `common` repo branch `feat/ui-core-thesa-analytics`.
- Contract gap: the thesa analytics engine supports ratio queries server-side, but `ThesaAnalyticsDataSource` does not expose them; the cache hit ratio is therefore computed from two scalars.

## Testing
- Mocked-transport contract tests assert the exact POST bodies and that no tenant/partition filters leak; ratio derivation unit-tested
- Widget tests cover inventory, gate KPIs + ratio, empty data, 400/403/503 friendly states, and inventory/gate failure independence
- `flutter analyze --no-fatal-infos` clean, `dart format` clean (touched files), `flutter test` green (16 tests)